### PR TITLE
updated package system repair

### DIFF
--- a/usr/bin/lite-tweaks
+++ b/usr/bin/lite-tweaks
@@ -243,7 +243,20 @@ fi
 # Check if ARRAYB is empty
 # If it is skip the execution
 if [ ${#ARRAYB[@]} -ne 0 ]; then
-    gksudo /usr/bin/lite-tweaks-super "${ARRAYB[@]}"      # Open the next file with superuser privileges and pass the array B
+# Check administrative privileges
+   zenity --question --title="     Lite Tweaks - Are you Administrator?" \
+	      --width=420 --height=60 --icon-name=info \
+		  --text="\n<b>Some tasks require administrative privileges for execution</b>   \nYou will be prompted for credentials next. \n \nPress 'No' to exit now or 'Yes' to continue." --no-wrap
+   case $? in
+   	0)
+	gksudo  /usr/bin/lite-tweaks-super "${ARRAYB[@]}"  # Open the next file with superuser privileges and pass the array B
+	;;
+    # Abort Dialog
+	1) zenity --info --title="     Lite Tweaks - Aborted" \
+		   --width=240 --height=60 --icon-name=info \
+		   --text="\nSelected tasks have been aborted. \nNo changes to the system have been made." --no-wrap
+		return
+	esac
 fi
 
 if zenity --question --title="Lite Tweaks" --text="Process(s) complete.\nWould you like to continue using Lite Tweaks?"; then

--- a/usr/bin/lite-tweaks
+++ b/usr/bin/lite-tweaks
@@ -258,7 +258,8 @@ if [ ${#ARRAYB[@]} -ne 0 ]; then
 	esac
 fi
 
-if zenity --question --title="Lite Tweaks" --text="Process(s) complete.\nWould you like to continue using Lite Tweaks?"; then
+if zenity --question --width=280 --height=60 --icon-name=info --title="     Lite Tweaks Info" \
+	  --text="\n<b>Process completed</b>.\n \nWould you like to continue using Lite Tweaks?"; then
     return
 else
     exit 0

--- a/usr/bin/lite-tweaks
+++ b/usr/bin/lite-tweaks
@@ -2,7 +2,7 @@
 #--------------------------------------------------------------------------------------------------------
 # Name: Lite Tweaks
 # Description: A collection of tools to tweak your Linux Lite system.
-# Authors: Misko_2083, John Jenkins, Jerry Bezencon
+# Authors: Misko_2083, John Jenkins, Jerry Bezencon, Ralphy
 # Website: https://www.linuxliteos.com
 #--------------------------------------------------------------------------------------------------------
 
@@ -244,17 +244,16 @@ fi
 # If it is skip the execution
 if [ ${#ARRAYB[@]} -ne 0 ]; then
 # Check administrative privileges
-   zenity --question --title="     Lite Tweaks - Are you Administrator?" \
-	      --width=420 --height=60 --icon-name=info \
-		  --text="\n<b>Some tasks require administrative privileges for execution</b>   \nYou will be prompted for credentials next. \n \nPress 'No' to exit now or 'Yes' to continue." --no-wrap
+   zenity --question --width=420 --height=60 --icon-name=info \
+   	  --title="     Lite Tweaks - Are you Administrator?" \
+	  --text="\n<b>Some tasks require administrative privileges for execution</b>   \nYou will be prompted for credentials next. \n \nPress 'No' to exit now or 'Yes' to continue." --no-wrap
    case $? in
    	0)
 	gksudo  /usr/bin/lite-tweaks-super "${ARRAYB[@]}"  # Open the next file with superuser privileges and pass the array B
 	;;
     # Abort Dialog
-	1) zenity --info --title="     Lite Tweaks - Aborted" \
-		   --width=240 --height=60 --icon-name=info \
-		   --text="\nSelected tasks have been aborted. \nNo changes to the system have been made." --no-wrap
+	1) zenity --info --width=240 --height=60 --icon-name=info --title="     Lite Tweaks - Aborted" \
+		  --text="\nSelected tasks have been aborted. \nNo changes to the system have been made." --no-wrap
 		return
 	esac
 fi

--- a/usr/bin/lite-tweaks-super
+++ b/usr/bin/lite-tweaks-super
@@ -555,7 +555,7 @@ sudo apt-get install -f
             if [ "${PIPESTATUS[0]}" -ne "0" ]; then
                     echo "#Error"
                     sleep 1
-                    zenity --error --width=320 --height=80 --title="     Lite Tweaks - Error"
+                    zenity --error --width=320 --height=80 --title="     Lite Tweaks - Error" \
 		    	   --text="There was an error while\nInstalling partialy installed packages!"
                     return
             fi

--- a/usr/bin/lite-tweaks-super
+++ b/usr/bin/lite-tweaks-super
@@ -524,7 +524,17 @@ sleep 2
 }
 
 FIXAPT() {
-    echo "#Stage 1: Repairing the package system."$"\nPlease wait, this might take some time..."
+# Check Internet access
+echo "#Stage 1: Checking for internet connection..."
+	if eval "sudo -u ${SUDO_USER:-$USER} curl -sk https://www.linuxliteos.com/" >> /dev/null 2>&1; then
+	: # pass
+	else # Prompt ERROR internet connection
+		(zenity --info --ok-label="Got it!" --title="Lite Tweaks - No Internet connection detected" \
+			--text="\n<b>Your computer does not seem to be connected to the internet</b> \n \nPackage System Repair requires internet access in order to fetch package lists. \nPlease check your Internet connection and try again. The task will now abort." --no-wrap)
+     		break    			
+	fi
+# Stage 1
+echo "#Stage 1: Repairing the package system."$"\nPlease wait, this might take some time..."
 sudo apt-get clean
 cd /var/lib/apt
 sudo mv lists lists.old
@@ -532,36 +542,96 @@ sudo mkdir -p lists/partial
 sudo apt-get clean
 sudo apt-get update
             if [ "${PIPESTATUS[0]}" -ne "0" ]; then
-                        echo "#Error"
-                    sleep 2
-                                        zenity --error \
-                                        --title="Error" --text="There was an error while\nFetching package lists!"
-                    return
-                        fi
-    echo "#Stage 2: Repairing the package system."$"\nPlease wait, this might take some time..."
+                    echo "#Error"
+                    sleep 1
+                    zenity --error --width=320 --height=80 --title="     Lite Tweaks - Error" \
+			   --text="\nThere was an error while fetching package lists! \n \nCheck your system log for more details."
+                    break
+            fi
+# Stage 2
+echo "#Stage 2: Repairing the package system."$"\nPlease wait, this might take some time..."
 
 sudo apt-get install -f
             if [ "${PIPESTATUS[0]}" -ne "0" ]; then
-                        echo "#Error"
-                    sleep 2
-                                        zenity --error \
-                                        --title="Error" --text="There was an error while\nInstalling partialy installed packages!"
+                    echo "#Error"
+                    sleep 1
+                    zenity --error --width=320 --height=80 --title="     Lite Tweaks - Error"
+		    	   --text="There was an error while\nInstalling partialy installed packages!"
                     return
-                        fi
-    echo "#Stage 3: Repairing the package system."$"\nPlease wait, this might take some time..."
+            fi
+# Stage 3    
+echo "#Stage 3: Repairing the package system."$"\nPlease wait, this might take some time..."
 
-# Check for /etc/apt/sources.list.save file.If the file is not present then run...
-if [ !  -f /etc/apt/sources.list.save ]; then
-    sudo mv /etc/apt/sources.list /etc/apt/sources.list.bak
-    sudo touch /etc/apt/sources.list
-    sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) main universe restricted multiverse"
-fi
+# Check for /etc/apt/sources.list.save file...
+	# If file exists:
+	if  [ -f /etc/apt/sources.list.save ]; then
+		rm -f /etc/apt/sources.list.save &&  rm -f /etc/apt/sources.list.save
+		touch /etc/apt/sources.list
+		add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) main universe restricted multiverse"
+		cp /etc/apt/sources.list /etc/apt/sources.list.save
+	# If file does not exist:
+	elif [ !  -f /etc/apt/sources.list.save ]; then
+		rm -f /etc/apt/sources.list
+    		touch /etc/apt/sources.list
+    		add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) main universe restricted multiverse"
+		cp /etc/apt/sources.list /etc/apt/sources.list.save
+	fi
+	
+	#Check the release version to reset /etc/apt/sources.list.d/linuxlite.list 
+		LLVER=$(awk '{print $3}' /etc/llver) 
+		RELNUM=$( echo "$LLVER / 1" | bc )	# Get Release number and remove
+		REL_VERSION_NAME=(beryl citrine)	# Set Release version name array
+		# Update /etc/apt/sources.list.d/linuxlite.list for BERYL
+		if [ "$RELNUM" == "2"  ]; then		
+			# Check for /etc/apt/sources.list.d/linuxlite.list file... 
+				# If file exists:
+				if  [ -f /etc/apt/sources.list.d/linuxlite.list.save ]; then
+				rm -f /etc/apt/sources.list.d/linuxlite.list && rm -f /etc/apt/sources.list.d/linuxlite.list.save
+				touch /etc/apt/sources.list.d/linuxlite.list
+				echo "deb http://repo.linuxliteos.com/linuxlite/ ${REL_VERSION_NAME[0]} main" >> /etc/apt/sources.list.d/linuxlite.list
+				cp /etc/apt/sources.list.d/linuxlite.list  /etc/apt/sources.list.d/linuxlite.list.save
+				echo "$RELVERSION"
+	
+				 # If file does not exist:
+				elif [ !  -f /etc/apt/sources.list.d/linuxlite.list.save ]; then
+				rm -f /etc/apt/sources.list.d/linuxlite.list
+				touch /etc/apt/sources.list.d/linuxlite.list
+				echo "deb http://repo.linuxliteos.com/linuxlite/ ${REL_VERSION_NAME[0]} main" >> /etc/apt/sources.list.d/linuxlite.list
+				cp /etc/apt/sources.list.d/linuxlite.list  /etc/apt/sources.list.d/linuxlite.list.save
+				fi
+		# Update /etc/apt/sources.list.d/linuxlite.list for CITRINE
+		elif [ "$RELNUM" == "3"  ]; then
+			# Check for /etc/apt/sources.list.d/linuxlite.list file... 
+				# If file exists:
+				if  [ -f /etc/apt/sources.list.d/linuxlite.list.save ]; then
+				rm -f /etc/apt/sources.list.d/linuxlite.list && rm -f /etc/apt/sources.list.d/linuxlite.list.save
+				touch /etc/apt/sources.list.d/linuxlite.list
+				echo "deb http://repo.linuxliteos.com/linuxlite/ ${REL_VERSION_NAME[1]} main" >> /etc/apt/sources.list.d/linuxlite.list
+				cp /etc/apt/sources.list.d/linuxlite.list  /etc/apt/sources.list.d/linuxlite.list.save
+				echo "$RELVERSION"
+	
+				 # If file does not exist:
+				elif [ !  -f /etc/apt/sources.list.d/linuxlite.list.save ]; then
+				rm -f /etc/apt/sources.list.d/linuxlite.list
+				touch /etc/apt/sources.list.d/linuxlite.list
+				echo "deb http://repo.linuxliteos.com/linuxlite/ ${REL_VERSION_NAME[1]} main" >> /etc/apt/sources.list.d/linuxlite.list
+				cp /etc/apt/sources.list.d/linuxlite.list  /etc/apt/sources.list.d/linuxlite.list.save
+				fi
+		# DON'T UPDATE UNSUPPORTED RELEASE - Sample
+		elif [ "$RELNUM" == "4" ]; then
+		 zenity --warning \
+					--width=320 --height=80 \
+                                        --title="     Lite Tweaks - Warning" --text="\n<b>Unsupported Linux Lite release version found</b> \n \n/etc/apt/sources.list.d/linuxlite.list and /etc/apt/sources.list.d/linuxlite.list.save files will not be reset. "
+		next
+	fi
+# Unset variables used during FIXAPT
+unset REL_VERSION_NAME
+unset RELNUM
+unset LLVER
 
-sudo rm /etc/apt/sources.list
-sudo cp /etc/apt/sources.list.save /etc/apt/sources.list
 sudo apt-get update
-
-    echo "#Final Stage: Repairing the package system."$"\nCompleting Repair..."
+# Final Stage
+echo "#Final Stage: Repairing the package system."$"\nCompleting Repair..."
 
 sudo dpkg --configure -a
 }

--- a/usr/bin/lite-tweaks-super
+++ b/usr/bin/lite-tweaks-super
@@ -2,7 +2,7 @@
 #--------------------------------------------------------------------------------------------------------
 # Name: Lite Tweaks Super
 # Description: A collection of tools to tweak your Linux Lite system.
-# Authors: Misko_2083, John Jenkins, Jerry Bezencon
+# Authors: Misko_2083, John Jenkins, Jerry Bezencon, Ralphy
 # Website: https://www.linuxliteos.com
 #--------------------------------------------------------------------------------------------------------
 

--- a/usr/bin/lite-tweaks-super
+++ b/usr/bin/lite-tweaks-super
@@ -565,7 +565,7 @@ echo "#Stage 3: Repairing the package system."$"\nPlease wait, this might take s
 # Check for /etc/apt/sources.list.save file...
 	# If file exists:
 	if  [ -f /etc/apt/sources.list.save ]; then
-		rm -f /etc/apt/sources.list.save &&  rm -f /etc/apt/sources.list.save
+		rm -f /etc/apt/sources.list.save &&  rm -f /etc/apt/sources.list
 		touch /etc/apt/sources.list
 		add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) main universe restricted multiverse"
 		cp /etc/apt/sources.list /etc/apt/sources.list.save
@@ -586,14 +586,13 @@ echo "#Stage 3: Repairing the package system."$"\nPlease wait, this might take s
 			# Check for /etc/apt/sources.list.d/linuxlite.list file... 
 				# If file exists:
 				if  [ -f /etc/apt/sources.list.d/linuxlite.list.save ]; then
-				rm -f /etc/apt/sources.list.d/linuxlite.list && rm -f /etc/apt/sources.list.d/linuxlite.list.save
+				rm -f /etc/apt/sources.list.d/linuxlite.list.save && rm -f /etc/apt/sources.list.d/linuxlite.list
 				touch /etc/apt/sources.list.d/linuxlite.list
 				echo "deb http://repo.linuxliteos.com/linuxlite/ ${REL_VERSION_NAME[0]} main" >> /etc/apt/sources.list.d/linuxlite.list
 				cp /etc/apt/sources.list.d/linuxlite.list  /etc/apt/sources.list.d/linuxlite.list.save
-				echo "$RELVERSION"
 	
-				 # If file does not exist:
-				elif [ !  -f /etc/apt/sources.list.d/linuxlite.list.save ]; then
+				# If file does not exist:
+				elif [ ! -f /etc/apt/sources.list.d/linuxlite.list.save ]; then
 				rm -f /etc/apt/sources.list.d/linuxlite.list
 				touch /etc/apt/sources.list.d/linuxlite.list
 				echo "deb http://repo.linuxliteos.com/linuxlite/ ${REL_VERSION_NAME[0]} main" >> /etc/apt/sources.list.d/linuxlite.list
@@ -610,8 +609,8 @@ echo "#Stage 3: Repairing the package system."$"\nPlease wait, this might take s
 				cp /etc/apt/sources.list.d/linuxlite.list  /etc/apt/sources.list.d/linuxlite.list.save
 				echo "$RELVERSION"
 	
-				 # If file does not exist:
-				elif [ !  -f /etc/apt/sources.list.d/linuxlite.list.save ]; then
+				# If file does not exist:
+				elif [ ! -f /etc/apt/sources.list.d/linuxlite.list.save ]; then
 				rm -f /etc/apt/sources.list.d/linuxlite.list
 				touch /etc/apt/sources.list.d/linuxlite.list
 				echo "deb http://repo.linuxliteos.com/linuxlite/ ${REL_VERSION_NAME[1]} main" >> /etc/apt/sources.list.d/linuxlite.list
@@ -619,9 +618,8 @@ echo "#Stage 3: Repairing the package system."$"\nPlease wait, this might take s
 				fi
 		# DON'T UPDATE UNSUPPORTED RELEASE - Sample
 		elif [ "$RELNUM" == "4" ]; then
-		 zenity --warning \
-					--width=320 --height=80 \
-                                        --title="     Lite Tweaks - Warning" --text="\n<b>Unsupported Linux Lite release version found</b> \n \n/etc/apt/sources.list.d/linuxlite.list and /etc/apt/sources.list.d/linuxlite.list.save files will not be reset. "
+		 zenity --warning --width=320 --height=80 --title="     Lite Tweaks - Warning" \
+		 --text="\n<b>Unsupported Linux Lite release version found</b> \n \n/etc/apt/sources.list.d/linuxlite.list and /etc/apt/sources.list.d/linuxlite.list.save files will not be reset. "
 		next
 	fi
 # Unset variables used during FIXAPT
@@ -629,11 +627,12 @@ unset REL_VERSION_NAME
 unset RELNUM
 unset LLVER
 
-sudo apt-get update
+apt-get update
+
 # Final Stage
 echo "#Final Stage: Repairing the package system."$"\nCompleting Repair..."
+dpkg --configure -a
 
-sudo dpkg --configure -a
 }
 
     x=0


### PR DESCRIPTION
- added dialog to let user know why administrator credentials are needed, when needed
- added confirmation dialog on cancellation before continuing with lite-tweaks-super
- remove 'sudo' from all commands (elevation is granted during admin credentials request)   
- added checks for internet connection (as user - not as root) before FIXAPT 
- cancel FIXAPT if no internet connection is available
- added dialog informing user about FIXAPT cancellation
- updated package system repair login
- included checks for release version (beryl citrine) and reset linuxlite.list accordingly
- added warning dialog for unsupported release version e.g.: 4.0 to inform user linuxlite.list won't be reset
- Few dialogs (window size) updated
